### PR TITLE
Fix public repos not working with invalid token

### DIFF
--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -11,8 +11,19 @@ export const getRepo = (
 		auth: token || process.env.REACT_APP_GITHUB_TOKEN,
 	});
 
-	return octokit.rest.repos.get({
-		owner,
-		repo,
-	});
+	return (
+		octokit.rest.repos
+			.get({
+				owner,
+				repo,
+			})
+			// public repos fail if the provided token is invalid. If the request fails, try again without a token
+			.catch(() =>
+				octokit.rest.repos.get({
+					owner,
+					repo,
+					headers: { authorization: '' },
+				}),
+			)
+	);
 };


### PR DESCRIPTION
Fix public repos not working with invalid token

Change-type: patch
Signed-off-by: Matthew Yarmolinsky <matthew-timothy@balena.io>